### PR TITLE
支持快捷键查单词

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -111,6 +111,30 @@ const getDailyTask = () => {
   }
 }
 
+/**
+ * 根据网页上选择的文本进行查询
+ */
+const LookUpBySelection = async (tabId) => {
+  try {
+    // 获取网页中选择的文本
+    const [{result}] = await chrome.scripting.executeScript({
+      target: {tabId: tabId},
+      func: () => getSelection().toString(),
+    });
+
+    // 查询单词
+    const res = await lookUp(result);
+    const existsRes = await checkWordAdded(res.id);
+    res.exists = existsRes.objects[0].exists;
+    res.__shanbayExtensionSettings = {autoRead: storage.autoRead};
+
+    // 发送事件，弹窗
+    chrome.tabs.sendMessage(tabId, {action: 'lookup', data: res});
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 chrome.storage.onChanged.addListener(changes => {
   const settings = changes.__shanbayExtensionSettings.newValue
   if (Object.keys(settings).length) {
@@ -154,3 +178,14 @@ chrome.storage.sync.get('__shanbayExtensionSettings', (settings) => {
   })
   getDailyTask()
 })
+
+chrome.commands.onCommand.addListener(async (command, tab) => {
+  switch (command) {
+    case "look-up-in-shanbay":
+      LookUpBySelection(tab.id);
+      break;
+
+    default:
+      break;
+  }
+});

--- a/js/background.js
+++ b/js/background.js
@@ -114,7 +114,7 @@ const getDailyTask = () => {
 /**
  * 根据网页上选择的文本进行查询
  */
-const LookUpBySelection = async (tabId) => {
+const lookUpBySelection = async (tabId) => {
   try {
     // 获取网页中选择的文本
     const [{result}] = await chrome.scripting.executeScript({
@@ -182,7 +182,7 @@ chrome.storage.sync.get('__shanbayExtensionSettings', (settings) => {
 chrome.commands.onCommand.addListener(async (command, tab) => {
   switch (command) {
     case "look-up-in-shanbay":
-      LookUpBySelection(tab.id);
+      lookUpBySelection(tab.id);
       break;
 
     default:

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,11 @@
     "service_worker": "js/background.js",
     "type": "module"
   },
+  "commands": {
+    "look-up-in-shanbay": {
+      "description": "Look up a word in shanbay"
+    }
+  },
   "action": {
     "default_icon": "images/icon_48.png",
     "default_popup": "popup.html",
@@ -31,8 +36,8 @@
       ],
       "matches": ["<all_urls>"],
       "exclude_matches": [
-        "*://*.shanbay.com/*", 
-        "*://*.hjenglish.com/*", 
+        "*://*.shanbay.com/*",
+        "*://*.hjenglish.com/*",
         "*://*.codepen.io/*",
         "*://*.jsfiddle.net/*",
         "*://*.jsbin.com/*",
@@ -51,6 +56,8 @@
     "storage",
     "alarms",
     "notifications",
-    "offscreen"
+    "offscreen",
+    "scripting",
+    "activeTab"
   ]
 }


### PR DESCRIPTION
- 支持在 chrome 扩展-自定义快捷键界面设置扇贝查单词快捷键，然后通过快捷键唤起插件查单词，效果：

<img width="1059" alt="image" src="https://github.com/maicss/chrome-shanbay-v2/assets/16575052/67ab1ae7-7b98-4610-a05c-88b01a8440a8">
 
<img width="501" alt="image" src="https://github.com/maicss/chrome-shanbay-v2/assets/16575052/c0607b67-b643-43e4-9c6c-5da1a64cd388">
